### PR TITLE
Properly sanitize passwords in the logs again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <bitbucket.version>8.19.2</bitbucket.version>
         <bitbucket.test.version>${bitbucket.version}</bitbucket.test.version>
         <amps.version>8.9.2</amps.version>
+        <atlassian.spring.scanner.version>2.2.0</atlassian.spring.scanner.version>
     </properties>
 
     <dependencyManagement>
@@ -90,6 +91,18 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.atlassian.plugin</groupId>
+            <artifactId>atlassian-spring-scanner-annotation</artifactId>
+            <version>${atlassian.spring.scanner.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -108,6 +121,23 @@
                             <dataVersion>${bitbucket.test.version}</dataVersion>
                         </product>
                     </products>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.atlassian.plugin</groupId>
+                <artifactId>atlassian-spring-scanner-maven-plugin</artifactId>
+                <version>${atlassian.spring.scanner.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>atlassian-spring-scanner</goal>
+                        </goals>
+                        <phase>process-classes</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <!-- Enable this to get build-time logging of annotations atlassian-spring-scanner-maven-plugin has noticed -->
+                    <verbose>false</verbose>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.englishtown</groupId>
     <artifactId>stash-hook-mirror</artifactId>
-    <version>3.3.0-SNAPSHOT</version>
+    <version>3.3.1</version>
 
     <organization>
         <name>EF Learning Labs</name>
@@ -29,7 +29,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <bitbucket.version>8.15.1</bitbucket.version>
+        <bitbucket.version>8.19.2</bitbucket.version>
         <bitbucket.test.version>${bitbucket.version}</bitbucket.test.version>
         <amps.version>8.9.2</amps.version>
     </properties>

--- a/src/main/java/com/englishtown/bitbucket/hook/DefaultPasswordEncryptor.java
+++ b/src/main/java/com/englishtown/bitbucket/hook/DefaultPasswordEncryptor.java
@@ -1,7 +1,9 @@
 package com.englishtown.bitbucket.hook;
 
+import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
 import com.atlassian.sal.api.pluginsettings.PluginSettings;
 import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
+import org.springframework.stereotype.Component;
 
 import javax.crypto.*;
 import javax.crypto.spec.SecretKeySpec;
@@ -13,6 +15,7 @@ import java.util.Base64;
 /**
  * Service to encrypt/decrypt git user passwords
  */
+@Component
 public class DefaultPasswordEncryptor implements PasswordEncryptor {
 
     private SecretKey secretKey;
@@ -21,7 +24,7 @@ public class DefaultPasswordEncryptor implements PasswordEncryptor {
     static final String ENCRYPTED_PREFIX = "encrypted:";
     static final String SETTINGS_CRYPTO_KEY = "crypto.key";
 
-    public DefaultPasswordEncryptor(PluginSettingsFactory settingsFactory) {
+    public DefaultPasswordEncryptor(@ComponentImport PluginSettingsFactory settingsFactory) {
         PluginSettings pluginSettings = settingsFactory.createSettingsForKey(PLUGIN_SETTINGS_KEY);
 
         try {

--- a/src/main/java/com/englishtown/bitbucket/hook/DefaultSettingsReflectionHelper.java
+++ b/src/main/java/com/englishtown/bitbucket/hook/DefaultSettingsReflectionHelper.java
@@ -4,10 +4,12 @@ import com.atlassian.bitbucket.setting.Settings;
 
 import java.lang.reflect.Field;
 import java.util.Map;
+import org.springframework.stereotype.Component;
 
 /**
  * Default implementation of {@link SettingsReflectionHelper}
  */
+@Component
 public class DefaultSettingsReflectionHelper implements SettingsReflectionHelper {
 
     /**

--- a/src/main/java/com/englishtown/bitbucket/hook/MirrorBucketProcessor.java
+++ b/src/main/java/com/englishtown/bitbucket/hook/MirrorBucketProcessor.java
@@ -83,8 +83,8 @@ public class MirrorBucketProcessor implements BucketProcessor<MirrorRequest> {
     private void runMirrorCommand(MirrorSettings settings, Repository repository) {
         log.debug("{}: Preparing to push changes to mirror", repository);
 
-        String password = passwordEncryptor.decrypt(settings.password);
-        String authenticatedUrl = getAuthenticatedUrl(settings.mirrorRepoUrl, settings.username, password);
+        String unencryptedPassword = passwordEncryptor.decrypt(settings.password);
+        String authenticatedUrl = getAuthenticatedUrl(settings.mirrorRepoUrl, settings.username, unencryptedPassword);
 
         // Call push command with the prune flag and refspecs for heads and tags
         // Do not use the mirror flag as pull-request refs are included
@@ -116,7 +116,7 @@ public class MirrorBucketProcessor implements BucketProcessor<MirrorRequest> {
             builder.argument("+refs/notes/*:refs/notes/*");
         }
 
-        PasswordHandler passwordHandler = new PasswordHandler(settings.password,
+        PasswordHandler passwordHandler = new PasswordHandler(unencryptedPassword,
                 new GitCommandExitHandler(i18nService, repository));
 
         Command<String> command = builder.errorHandler(passwordHandler)

--- a/src/main/java/com/englishtown/bitbucket/hook/MirrorBucketProcessor.java
+++ b/src/main/java/com/englishtown/bitbucket/hook/MirrorBucketProcessor.java
@@ -11,9 +11,11 @@ import com.atlassian.bitbucket.scm.ScmService;
 import com.atlassian.bitbucket.scm.git.command.GitCommandExitHandler;
 import com.atlassian.bitbucket.server.ApplicationPropertiesService;
 import com.atlassian.bitbucket.user.SecurityService;
+import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
 import com.google.common.base.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
 import javax.annotation.Nonnull;
 import java.net.URI;
@@ -24,6 +26,7 @@ import java.util.Locale;
 
 import static com.englishtown.bitbucket.hook.MirrorRepositoryHook.PROP_PREFIX;
 
+@Component
 public class MirrorBucketProcessor implements BucketProcessor<MirrorRequest> {
 
     static final String PROP_TIMEOUT = PROP_PREFIX + "timeout";
@@ -39,9 +42,9 @@ public class MirrorBucketProcessor implements BucketProcessor<MirrorRequest> {
     private final SecurityService securityService;
     private final Duration timeout;
 
-    public MirrorBucketProcessor(I18nService i18nService, PasswordEncryptor passwordEncryptor,
-                                 ApplicationPropertiesService propertiesService, RepositoryService repositoryService,
-                                 ScmService scmService, SecurityService securityService) {
+    public MirrorBucketProcessor(@ComponentImport I18nService i18nService, PasswordEncryptor passwordEncryptor,
+                                 @ComponentImport ApplicationPropertiesService propertiesService, @ComponentImport RepositoryService repositoryService,
+                                 @ComponentImport ScmService scmService, SecurityService securityService) {
         this.i18nService = i18nService;
         this.passwordEncryptor = passwordEncryptor;
         this.repositoryService = repositoryService;

--- a/src/main/java/com/englishtown/bitbucket/hook/PasswordHandler.java
+++ b/src/main/java/com/englishtown/bitbucket/hook/PasswordHandler.java
@@ -24,13 +24,17 @@ class PasswordHandler extends StringOutputHandler
         this.target = ":" + password + "@";
     }
 
+    @Nonnull
     public String cleanText(String text) {
-        if (text == null || text.isEmpty()) {
+        if (text == null) {
+           return "";
+        } else if(text.isEmpty()) {
             return text;
         }
         return text.replace(target, PASSWORD_REPLACEMENT);
     }
 
+    @Nonnull
     @Override
     public String getOutput() {
         return cleanText(super.getOutput());
@@ -38,13 +42,28 @@ class PasswordHandler extends StringOutputHandler
 
     @Override
     public void onCancel(@Nonnull String command, int exitCode, @Nullable String stdErr, @Nullable Throwable thrown) {
-        exitHandler.onCancel(cleanText(command), exitCode, cleanText(stdErr), thrown);
+        exitHandler.onCancel(cleanText(command), exitCode, cleanText(stdErr), getPasswordSafeException(thrown));
     }
 
     @Override
     public void onExit(@Nonnull String command, int exitCode, @Nullable String stdErr, @Nullable Throwable thrown) {
-        exitHandler.onExit(cleanText(command), exitCode, cleanText(stdErr), thrown);
+        exitHandler.onExit(cleanText(command), exitCode, cleanText(stdErr), getPasswordSafeException(thrown));
     }
 
+    class PasswordSafeException extends Throwable {
+        public PasswordSafeException(Throwable thrown) {
+            super("Wrapping " + thrown.getClass().getSimpleName() + ": " + cleanText(thrown.getMessage()));
+            setStackTrace(thrown.getStackTrace());
+        }
+    }
+
+    @Nullable
+    private PasswordSafeException getPasswordSafeException(@Nullable Throwable thrown) {
+        PasswordSafeException exception = null;
+        if (thrown != null) {
+            exception = new PasswordSafeException(thrown);
+        }
+        return exception;
+    }
 }
 

--- a/src/main/resources/META-INF/spring/atlassian-spring-scanner.xml
+++ b/src/main/resources/META-INF/spring/atlassian-spring-scanner.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:atlassian-scanner="http://www.atlassian.com/schema/atlassian-scanner/2"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+        http://www.atlassian.com/schema/atlassian-scanner/2
+        http://www.atlassian.com/schema/atlassian-scanner/2/atlassian-scanner.xsd">
+    <atlassian-scanner:scan-indexes/>
+</beans>

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -11,24 +11,11 @@
         </permissions>
     </plugin-info>
 
-    <!-- Components that are injected -->
-    <component-import key="applicationPropertiesService" interface="com.atlassian.bitbucket.server.ApplicationPropertiesService"/>
-    <component-import key="concurrencyService" interface="com.atlassian.bitbucket.concurrent.ConcurrencyService"/>
-    <component-import key="i18nService" interface="com.atlassian.bitbucket.i18n.I18nService"/>
-    <component-import key="pluginSettingsFactory" interface="com.atlassian.sal.api.pluginsettings.PluginSettingsFactory"/>
-    <component-import key="repositoryService" interface="com.atlassian.bitbucket.repository.RepositoryService"/>
-    <component-import key="scmService" interface="com.atlassian.bitbucket.scm.ScmService"/>
-
-    <component key="mirrorRepositoryHook" class="com.englishtown.bitbucket.hook.MirrorRepositoryHook"/>
-    <component key="mirrorBucketProcessor" class="com.englishtown.bitbucket.hook.MirrorBucketProcessor"/>
-    <component key="passwordEncryptor" class="com.englishtown.bitbucket.hook.DefaultPasswordEncryptor"/>
-    <component key="settingsReflectionHelper" class="com.englishtown.bitbucket.hook.DefaultSettingsReflectionHelper"/>
-
     <!-- add our i18n resource -->
     <resource type="i18n" name="i18n" location="i18n/stash-hook-mirror"/>
 
     <repository-hook name="Mirror Repository Hook" i18n-name-key="mirror-repository-hook.name"
-                     key="mirror-repository-hook" class="bean:mirrorRepositoryHook"
+                     key="mirror-repository-hook" class="com.englishtown.bitbucket.hook.MirrorRepositoryHook"
                      configurable="true">
         <description key="mirror-repository-hook.description">Mirror Hook</description>
         <icon>icons/mirror-icon.png</icon>


### PR DESCRIPTION
The password scrubbing functionality was broken because it was looking for the encrypted password in the logs, not the unencrypted password. It also wasn't removing the password contained in the base error message. Those two things have been fixed.

There was also an issue where updating the plugin would cause the edit hook dialog to throw an error, preventing edits to settings until the Bitbucket host was restarted.  This was due to the `MirrorRequest` queue never being flushed and so it would hold onto the old instances of the class that could no longer be cast into the new instance types. To fix this I had to update the plugin's dependency injection to remove the old, deprecated style of putting `<component>` tags in the `atlassian-plugin.xml` file and instead use Spring annotation tags. This let me include actual Spring dependencies and have `MirrorRepositoryHook` implement `DisposableBean`.

Primary: @dalyndalton 